### PR TITLE
🚑️ Fix installation name settings

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,5 +38,8 @@
     "allow-plugins": {
       "getkirby/composer-installer": true
     }
+  },
+  "extra": {
+    "installer-name": "debugbar"
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "treast/kirby-debugbar",
   "description": "PHP Debug Bar for KirbyCMS",
   "type": "kirby-plugin",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "keywords": [
     "kirby",
     "kirbycms",


### PR DESCRIPTION
The plugin was installing in the wrong folder.